### PR TITLE
remove X-Requested-With: XMLHttpRequest header

### DIFF
--- a/src/core/plugins/auth/actions.js
+++ b/src/core/plugins/auth/actions.js
@@ -189,8 +189,7 @@ export const authorizeRequest = ( data ) => ( { fn, getConfigs, authActions, err
 
   let _headers = Object.assign({
     "Accept":"application/json, text/plain, */*",
-    "Content-Type": "application/x-www-form-urlencoded",
-    "X-Requested-With": "XMLHttpRequest"
+    "Content-Type": "application/x-www-form-urlencoded"
   }, headers)
 
   fn.fetch({


### PR DESCRIPTION
### Description
This PR effectively reverts the changes of PR https://github.com/swagger-api/swagger-ui/pull/4934 (or more specific the commit https://github.com/swagger-api/swagger-ui/commit/937c8f6208f3adf713b10a349a82a1b129bd0ffd).

### Motivation and Context
As described in more detail in issue https://github.com/swagger-api/swagger-ui/issues/6081, the use of the `X-Requested-With` header triggers a preflight on most authentication backends. Most authentication endpoints do not implement CORS, and when they do the header `X-Requested-With` is not in the list of allowed headers.

Note that the motivation of the original PR that introduced this change seems to be debatable. The popup shown in the screenshots there seem to be caused by a backend sending a `WWW-Authenticate` header, which is kind of weird.

Fixes #6081



### How Has This Been Tested?
Running the latest swagger-ui with Dex IDP (https://dexidp.io/). My browser fails to fetch the token after going through the authorization code flow. Replacing swagger-ui with a local build of this PR results in successful authentication.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [?] All new and existing tests passed.
